### PR TITLE
add applicationType option for server generator

### DIFF
--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -48,6 +48,12 @@ module.exports = class extends BaseBlueprintGenerator {
             defaults: false
         });
 
+        this.option('applicationType', {
+            desc: 'Indicates which applicationType to use',
+            type: String,
+            defaults: false
+        });
+
         // This adds support for a `--experimental` flag which can be used to enable experimental features
         this.option('experimental', {
             desc:
@@ -55,7 +61,10 @@ module.exports = class extends BaseBlueprintGenerator {
             type: Boolean,
             defaults: false
         });
-
+        this.applicationType = this.options.applicationType || this.configOptions.applicationType || this.config.get('applicationType');
+        if (!this.applicationType) {
+            this.applicationType = 'monolith';
+        }
         this.uaaBaseName = this.options.uaaBaseName || this.configOptions.uaaBaseName || this.config.get('uaaBaseName');
 
         this.setupServerOptions(this);
@@ -127,10 +136,6 @@ module.exports = class extends BaseBlueprintGenerator {
 
                 this.packagejs = packagejs;
                 const configuration = this.getAllJhipsterConfig(this, true);
-                this.applicationType = configuration.get('applicationType') || this.configOptions.applicationType;
-                if (!this.applicationType) {
-                    this.applicationType = 'monolith';
-                }
                 this.reactive = configuration.get('reactive') || this.configOptions.reactive;
                 this.reactiveRepository = this.reactive ? 'reactive/' : '';
                 this.packageName = configuration.get('packageName');


### PR DESCRIPTION
so the applicationType could be chosen even if we didn't go through the app generator (useful for unit testing)

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
